### PR TITLE
Add state option to login query string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export class WorkOSSSOStrategy extends Strategy {
 
   private _loginAttempt(req: Request, options: AuthenticateOptions) {
     try {
-      const { connection, domain, email } = req.query as Record<string, string>;
+      const { connection, domain, email, state } = req.query as Record<string, string>;
       if ([connection, domain, email].every((a) => a === undefined)) {
         throw Error(
           "One of 'connection', 'domain' and/or 'email' are required"
@@ -48,6 +48,7 @@ export class WorkOSSSOStrategy extends Strategy {
         domain: domain || email?.slice(email.indexOf("@") + 1),
         clientID: this.options.clientID,
         redirectURI: this.options.callbackURL || options.redirectURI,
+        state,
         ...options,
       });
       this.redirect(url);


### PR DESCRIPTION
hey @andyrichardson I want to leverage the [`state` parameter](https://workos.com/docs/reference/sso/authorize/get#authorize-state) so I added the variable to the login `req.query` and am passing it into `getAuthorizationURL`. Let me know if this looks ok