### PR TITLE
Update available connection selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,8 @@ app.get(
 
 ### Login
 
-The login route will redirect to a [WorkOS OAuth 2.0 authorization URL](https://workos.com/docs/reference/sso/authorize/get). When redirecting to this route, be sure to include one of the [supported query parameters](https://workos.com/docs/reference/sso/authorize/get#authorize-get-parameters)
-
-> **Note**
-> An additional `email` query parameter is supported which will extract the `domain` and forward it to WorkOS
-
-**Example**
-
-```
-location.href = "/auth/workos/login?domain=gmail.com"
-```
+The login route will redirect to a [WorkOS OAuth 2.0 authorization URL](https://workos.com/docs/reference/sso/get-authorization-url). When redirecting to this route, be sure to include one of the [supported query parameters](https://workos.com/docs/reference/sso/get-authorization-url)
 
 ### Callback
 
-This will be called by WorkOS after a successful login. Be sure to [configure the redirect URI](https://workos.com/docs/sso/guide/set-redirect-uri) with WorkOS.
+This will be called by WorkOS after a successful login. Be sure to [configure the redirect URI](https://workos.com/docs/reference/sso/redirect-uri) with WorkOS.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,5 @@
+import { ConnectionType } from "@workos-inc/node";
 import express from "express";
-import expressSession from "express-session";
 import passport from "passport";
 import supertest from "supertest";
 import { WorkOSSSOStrategy } from "./";
@@ -108,55 +108,57 @@ describe("on login", () => {
     });
   });
 
-  describe("on domain", () => {
-    const domain = "mydomain.org";
-    const url = `/workos/authorize?domain=${domain}`;
+  describe("on provider", () => {
+    describe("with 'GoogleOAuth'", () => {
+      const provider = ConnectionType.GoogleOAuth;
+      const url = `/workos/authorize?provider=${provider}`;
 
-    it("calls workos api with domain", async () => {
-      await supertest(app).get(url);
-      expect(getAuthorizationURL).toBeCalledTimes(1);
-      expect(getAuthorizationURL).toBeCalledWith(
-        expect.objectContaining({
-          domain,
-          clientID,
-          redirectURI: callbackURL,
-          state: "...",
-        })
-      );
+      it("calls workos api with provider", async () => {
+        await supertest(app).get(url);
+        expect(getAuthorizationURL).toBeCalledTimes(1);
+        expect(getAuthorizationURL).toBeCalledWith(
+          expect.objectContaining({
+            provider,
+            clientID,
+            redirectURI: callbackURL,
+            state: "...",
+          })
+        );
+      });
+
+      it("redirects to login url", async () => {
+        const res = await supertest(app).get(url);
+        expect(res.statusCode).toEqual(302);
+        expect(res.headers.location).toMatchInlineSnapshot(
+          `"https://workos.com/fake-auth-url"`
+        );
+      });
     });
 
-    it("redirects to login url", async () => {
-      const res = await supertest(app).get(url);
-      expect(res.statusCode).toEqual(302);
-      expect(res.headers.location).toMatchInlineSnapshot(
-        `"https://workos.com/fake-auth-url"`
-      );
-    });
-  });
+    describe("with 'MicrosoftOAuth'", () => {
+      const provider = ConnectionType.MicrosoftOAuth;
+      const url = `/workos/authorize?provider=${provider}`;
 
-  describe("on email", () => {
-    const email = "user@mydomain.org";
-    const url = `/workos/authorize?email=${email}`;
+      it("calls workos api with provider", async () => {
+        await supertest(app).get(url);
+        expect(getAuthorizationURL).toBeCalledTimes(1);
+        expect(getAuthorizationURL).toBeCalledWith(
+          expect.objectContaining({
+            provider,
+            clientID,
+            redirectURI: callbackURL,
+            state: "...",
+          })
+        );
+      });
 
-    it("calls workos api with domain", async () => {
-      await supertest(app).get(url);
-      expect(getAuthorizationURL).toBeCalledTimes(1);
-      expect(getAuthorizationURL).toBeCalledWith(
-        expect.objectContaining({
-          domain: email.substring(email.indexOf("@") + 1),
-          clientID,
-          redirectURI: callbackURL,
-          state: "...",
-        })
-      );
-    });
-
-    it("redirects to login url", async () => {
-      const res = await supertest(app).get(url);
-      expect(res.statusCode).toEqual(302);
-      expect(res.headers.location).toMatchInlineSnapshot(
-        `"https://workos.com/fake-auth-url"`
-      );
+      it("redirects to login url", async () => {
+        const res = await supertest(app).get(url);
+        expect(res.statusCode).toEqual(302);
+        expect(res.headers.location).toMatchInlineSnapshot(
+          `"https://workos.com/fake-auth-url"`
+        );
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,15 +45,13 @@ export class WorkOSSSOStrategy extends Strategy {
 
   private _loginAttempt(req: Request, options: AuthenticateOptions) {
     try {
-      const { connection, domain, email, organization } = req.query as Record<
+      const { connection, organization, provider } = req.query as Record<
         string,
         string
       >;
-      if (
-        [connection, domain, email, organization].every((a) => a === undefined)
-      ) {
+      if ([connection, organization, provider].every((a) => a === undefined)) {
         throw Error(
-          "One of 'connection', 'domain', 'organization' and/or 'email' are required"
+          "One of 'connection', 'organization', or 'provider' is required"
         );
       }
 
@@ -61,7 +59,7 @@ export class WorkOSSSOStrategy extends Strategy {
         ...req.body,
         connection,
         organization,
-        domain: domain || email?.slice(email.indexOf("@") + 1),
+        provider,
         clientID: this.options.clientID,
         redirectURI: options.redirectURI || this.options.callbackURL,
         ...options,


### PR DESCRIPTION
This PR updates the available connection selectors available for use with the Passport strategy.

### Added

Support for the `provider` connection selector has been added.

This allows sign-ins with [Google OAuth](https://workos.com/docs/integrations/google-oauth) and [Microsoft OAuth](https://workos.com/docs/integrations/microsoft-oauth).

### Removed

The `domain` connection selector is deprecated within WorkOS, and as a result the `domain` and `email` parameters have been removed.

**This is a breaking change.**