### PR TITLE
Allow passing options to `WorkOS` client constructor with `clientOptions`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "passport-workos",
-  "version": "0.0.2-beta.0",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "passport-workos",
-      "version": "0.0.2-beta.0",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
         "@tsconfig/node16": "^1.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export type WorkOSSSOStrategyOptions = {
   clientID: string;
   clientSecret: string;
   callbackURL: string;
+  clientOptions?: ConstructorParameters<typeof WorkOS>[1];
 };
 
 export type WorkOSSSOStrategyVerifyFn = (
@@ -32,7 +33,7 @@ export class WorkOSSSOStrategy extends Strategy {
     super();
     this.options = opts;
     this.verify = verify;
-    this.client = new WorkOS(opts.clientSecret);
+    this.client = new WorkOS(opts.clientSecret, opts.clientOptions);
   }
 
   public authenticate(req: Request, options: AuthenticateOptions) {


### PR DESCRIPTION
The constructor for the `WorkOS` class exported by `@workos-inc/node` takes a second parameter, which are additional options used to configure the API client.

This adds a new/optional `clientOptions` field to the existing `WorkOSSSOStrategyOptions` which is passed through directly to the `WorkOS` constructor. 
